### PR TITLE
[FIX] Syntax error in lua examples for Config Files

### DIFF
--- a/src/pages/en/esx_core/es_extended/config/adjustments.mdx
+++ b/src/pages/en/esx_core/es_extended/config/adjustments.mdx
@@ -45,7 +45,7 @@ With this config property you can specify if the GTA wanted level should be enab
 This config property specifies if it should disable certain parts of the player's hud.
 Set to `true` if you want to disable it and `false` to enable.
 ```lua
-RemoveHudComponents       = {
+Config.RemoveHudComponents       = {
 	[1] = false,  -- The player's wanted starts,
 	[2] = false,  -- The weapon icon of the current weapon.
 	[3] = false,  -- The player's cash (This is not used by ESX)
@@ -83,7 +83,7 @@ This config property specifies the plate pattern naturally spawned npc vehicles 
 
 **Example**
 ```lua
-CustomAIPlates = "ESX-^11EA" -- Example outcome: ESX-15EG
+Config.CustomAIPlates = "ESX-^11EA" -- Example outcome: ESX-15EG
 ```
 
 ### DiscordActivity

--- a/src/pages/en/esx_core/es_extended/config/logs.mdx
+++ b/src/pages/en/esx_core/es_extended/config/logs.mdx
@@ -19,7 +19,7 @@ This specifies the webhooks for specific functions. You can also add your own we
 Adding your own webhook:
 **Example**
 ```lua
-Webhooks = {
+Config.Webhooks = {
     default = '',
     test = '',
     Chat = '',

--- a/src/pages/en/esx_core/es_extended/config/main.mdx
+++ b/src/pages/en/esx_core/es_extended/config/main.mdx
@@ -52,7 +52,7 @@ This can be `false` if you don't want the player to receive anything. Or a table
 
 **Example**
 ```lua
-StartingInventoryItems = {
+Config.StartingInventoryItems = {
     bread = 2, -- Give the player 2 bread buns
     water = 4 -- Give the player 4 water bottles
 }

--- a/src/pages/en/esx_core/es_extended/config/main.mdx
+++ b/src/pages/en/esx_core/es_extended/config/main.mdx
@@ -36,7 +36,7 @@ With this config property you can specify how much money each account should hav
 
 **Example**
 ```lua
-StartingAccountMoney = {
+Config.StartingAccountMoney = {
     bank = 50000, -- Give the player 50 Thousand on his bank account
     money = 1500, -- Give the player 1500 cash.
     black_money = 500, -- Give the player 500 Black money,
@@ -64,7 +64,7 @@ You can specify one spawn or multiple.
 
 **Example**
 ```lua
-DefaultSpawns = { 
+Config.DefaultSpawns = { 
 	{x = 222.2027, y = -864.0162, z = 30.2922, heading = 1.0},
 	{x = 224.9865, y = -865.0871, z = 30.2922, heading = 1.0},
 	{x = 227.8436, y = -866.0400, z = 30.2922, heading = 1.0},
@@ -79,7 +79,7 @@ You can also use this by using the callback `esx:isUserAdmin`.
 
 **Example**
 ```lua
-AdminGroups = {
+Config.AdminGroups = {
 	['owner'] = true,
 	['sradmin'] = true,
   ['admin'] = true,


### PR DESCRIPTION
Fixed syntax error in different examples of lua code for config vars